### PR TITLE
create docker on release

### DIFF
--- a/.github/workflows/release_docker.yaml
+++ b/.github/workflows/release_docker.yaml
@@ -1,0 +1,36 @@
+name: Docker Image CI
+
+on:
+  release:
+    types: [published]
+
+
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+    steps:
+      -
+        name: Checkout
+        uses: actions/checkout@v3
+      -
+        name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+      -
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      -
+        name: Login to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+      -
+        name: Build and push version
+        uses: docker/build-push-action@v4
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: |
+            logzio/logzio-jumpcloud:${{ github.event.release.tag_name }}
+            logzio/logzio-jumpcloud:latest


### PR DESCRIPTION
This workflow builds and pushes a docker image upon release.
The release tag should have the version number