### PR TITLE
feat(main.py): allow usage of ENV variable instead of file configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,14 +25,14 @@ Create and edit the configuration file and name it `config.yaml` in the `logzio-
 | Parameter Name | Description | Required/Optional | Default |
 | --- | --- | --- | --- |
 | url | The Logz.io Listener URL for your region with port 8071. https://listener.logz.io:8071 | Required | - |
-| token | Your Logz.io log shipping token securely directs the data to your Logz.io account. | Required | - |
+| token | Your Logz.io log shipping token securely directs the data to your Logz.io account. | Optional (see  [Environment variables](###use-environment-variable)) | - |
 
 **Jumpcloud**
 | Parameter Name | Description | Required/Optional | Default |
 | --- | --- | --- | --- |
 | jumpcloud_api | A dictionary containing the JumpCloud API configurations. | Required | - |
 | start_date | The start date and time for querying the JumpCloud API in UTC time with the format of %Y-%m-%dT%H:%M:%S.%fZ. For example: 2023-05-04T12:30:00.000000Z. | Optional | The current date and time. |
-| credentials | A dictionary containing the token for authenticating the JumpCloud API request. | Required | - |
+| credentials | A dictionary containing the token for authenticating the JumpCloud API request. | (see  [Environment variables](###use-environment-variable)) | - |
 | token | The JumpCloud API token. | Required | - |
 | time_interval | The time interval for querying the JumpCloud API in minutes. | Optional |5m |
 
@@ -55,6 +55,12 @@ jumpcloud_api:
 ```shell
 docker run --name logzio-jumpcloud -v "$(pwd)":/app/src/shared logzio/logzio-jumpcloud
 ```
+### Use environment variable
+To allow a more secure delivery of your API tokens you can use two environment variables exported instead of providing them in the configuration:
+```shell
+docker run --name logzio-jumpcloud -e LOGZIO_API_TOKEN=<<LOGZIO_TOKEN>> -e JUMPCLOUD_API_TOKEN=<<JUMPCLOUD_API_TOKEN>> -v "$(pwd)":/app/src/shared logzio/logzio-jumpcloud
+```
+
 ### Stop Docker Container
 When you stop the container, the code will run until completion of the iteration. To make sure it will finish the iteration on time, please give it a grace period of 30 seconds when you run the docker stop command:
 ```shell

--- a/src/manager.py
+++ b/src/manager.py
@@ -5,7 +5,7 @@ from logzio_shipper import *
 from datetime import datetime, timedelta
 from urllib.parse import urlparse
 import urllib
-
+import os
 
 
 logger = logging.getLogger(__name__)
@@ -66,14 +66,13 @@ class Manager:
                 if data['logzio'] is None:
                     logger.error("The 'logzio' dictionary is None.")
                     return False
-                elif 'url' not in data['logzio'] or 'token' not in data['logzio']:
+                elif 'url' not in data['logzio'] or 'token' not in data['logzio'] and "LOGZIO_API_TOKEN" not in os.environ: # check the configuration or the environment variable
                     logger.error("Either 'url' or 'token' is missing from the 'logzio' dictionary.")
                     return False
 
             else:
                 logger.error("The key 'logzio' does not exist in the data dictionary.")
                 return False
-
             if 'jumpcloud_api' in data:
                 if data['jumpcloud_api'] is None:
                     logger.error("The 'jumpcloud_api' dictionary is None.")
@@ -82,7 +81,7 @@ class Manager:
                     if data['jumpcloud_api']['credentials'] is None:
                         logger.error("The 'credentials' dictionary in 'jumpcloud_api' is None.")
                         return False
-                    elif 'token' not in data['jumpcloud_api']['credentials']:
+                    elif 'token' not in data['jumpcloud_api']['credentials'] and "JUMPCLOUD_API_TOKEN" not in os.environ: # check the configuration or the environment variable
                         logger.error("The key 'token' is missing from the 'credentials' dictionary.")
                         return False
                 else:
@@ -128,14 +127,14 @@ class Manager:
             return False
 
         self.logzio_url = data['logzio']['url']
-        self.logzio_token = data['logzio']['token']
+        self.logzio_token = os.getenv("LOGZIO_API_TOKEN") if "LOGZIO_API_TOKEN" in os.environ else data['logzio']['token']
         self.jumpcloud_url = "https://api.jumpcloud.com/insights/directory/v1/events"
         self.last_time_event = data['jumpcloud_api']['start_date']
         if self.last_time_event is None or 'start_date' in data['jumpcloud_api']:
             self.last_time_event = datetime.utcnow().strftime('%Y-%m-%dT%H:%M:%S.%fZ')
         elif self.is_valid_format(str(self.last_time_event)):
             self.last_time_event = data['jumpcloud_api']['start_date']
-        self.jumpcloud_token = data['jumpcloud_api']['credentials']['token']
+        self.jumpcloud_token = os.getenv("JUMPCLOUD_API_TOKEN") if "JUMPCLOUD_API_TOKEN" in os.environ else data['jumpcloud_api']['credentials']['token']
         self.headers = {
             "accept": "application/json",
             "x-api-key": self.jumpcloud_token,


### PR DESCRIPTION
The idea of this commit is to allow the usage of ENV Variable to authenticate to the APIs
It will ease the deployment process for instance as a task in a cluster (ECS/EKS)
It will also avoid having clear secrets stored in a file in the container