### PR TITLE
fix(timestamp): use event timestamp instead of ingested one

### DIFF
--- a/src/manager.py
+++ b/src/manager.py
@@ -166,6 +166,7 @@ class Manager:
             if len(events) != 0:
                 logger.info("Events number: {}".format(len(events)))
                 for event in events:
+                    event["@timestamp"] = event["timestamp"]
                     if "changes" in event:
                         event["changes"] = self.changesValueToJSON(event["changes"])
                         event_str = json.dumps(event)


### PR DESCRIPTION
The timestamp that logz.io prints is the timestamp for the ingestion in logz.io, it should be the timestamp of the event.
Using the field `@timestamp` set it to the right time in UTC